### PR TITLE
Check if ip_address array has sufficient length

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "cloudstack_instance" "this" {
   zone             = var.zone
   network_id       = var.network_id
   root_disk_size   = var.root_disk_size
-  ip_address       = var.ip_address[count.index]
+  ip_address       = length(var.ip_address) > count.index ? var.ip_address[count.index] : null
   expunge          = true
 }
 


### PR DESCRIPTION
Esp. applies if the default array is not filled (var.ip_address is empty
list of string).